### PR TITLE
Updated to work with the current versions of data-model and core-utils-lib

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,9 @@ A Client for running nanopore-parser. nanopore-parser-cli is designed to interop
 Features
 --------
 
-* TODO
+This tool is responsible for validating a given filetree against the Nanopore filestructure at QBiC.
+Nanopore-parser-cli runs NanoporeParser from core-utils-lib(https://github.com/qbicsoftware/core-utils-lib),
+which converts the given filetree into Json Format and compares it with an established internal Json Schema.
 
 Credits
 -------

--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,21 @@ This tool is responsible for validating a given filetree against the Nanopore fi
 Nanopore-parser-cli runs NanoporeParser from core-utils-lib(https://github.com/qbicsoftware/core-utils-lib),
 which converts the given filetree into Json Format and compares it with an established internal Json Schema.
 
+Usage
+--------
+
+To use nanopore-parser-cli in a project::
+
+nanopore-parser-cli is intended as a standalone program, which functions through the usage of the commandline.
+The commandline provides the compiled jar file with the path to the filetree which is inspected for validation.
+
+To run nanopore-parser-cli use the following command:
+
+java -jar target/nanopore-parser-cli-1.0.0-SNAPSHOT-jar-with-dependencies.jar -p "<FileTreePath>"
+
+-p is the argument into which the path of the investigated filetree should be put.
+
+
 Credits
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -26,16 +26,16 @@ which converts the given filetree into Json Format and compares it with an estab
 Usage
 --------
 
-To use nanopore-parser-cli in a project::
+To use :code:`nanopore-parser-cli` in a project:
 
-nanopore-parser-cli is intended as a standalone program, which functions through the usage of the commandline.
+:code:`nanopore-parser-cli` is intended as a standalone program, which functions through the usage of the commandline.
 The commandline provides the compiled jar file with the path to the filetree which is inspected for validation.
 
 To run nanopore-parser-cli use the following command:
 
-java -jar target/nanopore-parser-cli-1.0.0-SNAPSHOT-jar-with-dependencies.jar -p "<FileTreePath>"
+:code:`java -jar target/nanopore-parser-cli-1.0.0-SNAPSHOT-jar-with-dependencies.jar -p "<FileTreePath>"`
 
--p is the argument into which the path of the investigated filetree should be put.
+:code:`-p` is the argument into which the path of the investigated filetree should be put.
 
 
 Credits

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,13 +2,13 @@
 Usage
 =====
 
-To use nanopore-parser-cli in a project::
+To use :code:`nanopore-parser-cli` in a project:
 
-nanopore-parser-cli is intended as a standalone program, which functions through the usage of the commandline.
+:code:`nanopore-parser-cli` is intended as a standalone program, which functions through the usage of the commandline.
 The commandline provides the compiled jar file with the path to the filetree which is inspected for validation.
 
 To run nanopore-parser-cli use the following command:
 
-java -jar target/nanopore-parser-cli-1.0.0-SNAPSHOT-jar-with-dependencies.jar -p "<FileTreePath>"
+:code:`java -jar target/nanopore-parser-cli-1.0.0-SNAPSHOT-jar-with-dependencies.jar -p "<FileTreePath>"`
 
--p is the argument into which the path of the investigated filetree should be put.
+:code:`-p` is the argument into which the path of the investigated filetree should be put.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -4,4 +4,11 @@ Usage
 
 To use nanopore-parser-cli in a project::
 
-    import nanopore-parser-cli
+nanopore-parser-cli is intended as a standalone program, which functions through the usage of the commandline.
+The commandline provides the compiled jar file with the path to the filetree which is inspected for validation.
+
+To run nanopore-parser-cli use the following command:
+
+java -jar target/nanopore-parser-cli-1.0.0-SNAPSHOT-jar-with-dependencies.jar -p "<FileTreePath>"
+
+-p is the argument into which the path of the investigated filetree should be put.

--- a/pom.xml
+++ b/pom.xml
@@ -50,12 +50,12 @@
 		<dependency>
 		<groupId>life.qbic</groupId>
 		<artifactId>core-utils-lib</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.4.0</version>
 	</dependency>
 	<dependency>
 		<groupId>life.qbic</groupId>
 		<artifactId>data-model-lib</artifactId>
-		<version>1.7.0-SNAPSHOT</version>
+		<version>1.8.0</version>
 	</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,10 +48,15 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>life.qbic</groupId>
-			<artifactId>core-utils-lib</artifactId>
-			<version>1.0.0</version>
-		</dependency>
+		<groupId>life.qbic</groupId>
+		<artifactId>core-utils-lib</artifactId>
+		<version>1.3.0-SNAPSHOT</version>
+	</dependency>
+	<dependency>
+		<groupId>life.qbic</groupId>
+		<artifactId>data-model-lib</artifactId>
+		<version>1.7.0-SNAPSHOT</version>
+	</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/life/qbic/cli/NanoporeCommand.java
+++ b/src/main/java/life/qbic/cli/NanoporeCommand.java
@@ -1,5 +1,6 @@
 package life.qbic.cli;
 
+import java.nio.file.Path;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -22,4 +23,6 @@ public class NanoporeCommand extends AbstractCommand {
     //
     //            If you need a custom constructor, make sure to provide a no-arguments public constructor as well.
     //            See: https://docs.oracle.com/javase/tutorial/java/javaOO/constructors.html
+    @Option(names={"-p", "--path"}, description="Path specifying Nanopore instrument output directory", required=true)
+    Path path;
 }

--- a/src/main/java/life/qbic/cli/NanoporeTool.java
+++ b/src/main/java/life/qbic/cli/NanoporeTool.java
@@ -1,5 +1,8 @@
 package life.qbic.cli;
 
+import java.nio.file.Path;
+import java.util.Map;
+import life.qbic.utils.NanoporeParser;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -23,10 +26,19 @@ public class NanoporeTool extends QBiCTool<NanoporeCommand> {
     public void execute() {
         // get the parsed command-line arguments
         final NanoporeCommand command = super.getCommand();
+        LOG.debug("Starting Nanopore tool");
+        Map NanoporeOutputMap = runNanoporeParser(command.path);
+        System.out.println(NanoporeOutputMap);
+        LOG.debug("Ending Nanopore tool");
+    }
+    //ToDo Switch Map for NanoporeExperiment as soon as it works
+    private Map runNanoporeParser(Path path) {
 
-        // TODO: do something useful with the obtained command.
-        //
+        Map nanoporeOutputMap = NanoporeParser.parseFileStructure(path);
+        return nanoporeOutputMap;
 
+        //OxfordNanoporeExperiment oxfordNanoporeExperiment = NanoporeParser.parseFileStructure(path);
+        // return oxfordNanoporeExperiment;
     }
 
     // TODO: override the shutdown() method if you are implementing a daemon and want to take advantage of a shutdown hook for clean-up tasks

--- a/src/main/java/life/qbic/cli/NanoporeTool.java
+++ b/src/main/java/life/qbic/cli/NanoporeTool.java
@@ -2,6 +2,7 @@ package life.qbic.cli;
 
 import java.nio.file.Path;
 import java.util.Map;
+import life.qbic.datamodel.datasets.OxfordNanoporeExperiment;
 import life.qbic.utils.NanoporeParser;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -28,22 +29,15 @@ public class NanoporeTool extends QBiCTool<NanoporeCommand> {
         final NanoporeCommand command = super.getCommand();
         LOG.info("Executing NanoporeParser to validate Directory");
         try {
-            Map NanoporeOutputMap = runNanoporeParser(command.path);
+            OxfordNanoporeExperiment nanoporeOutputExperiment = runNanoporeParser(command.path);
             LOG.info("Validation process executed successfully");
         } catch (Exception e) {
             LOG.error(e.getMessage());
         }
     }
-    //ToDo Switch Map for NanoporeExperiment as soon as it works
+    private OxfordNanoporeExperiment runNanoporeParser(Path path) {
 
-    private Map runNanoporeParser(Path path) {
-
-        Map nanoporeOutputMap = NanoporeParser.parseFileStructure(path);
-        return nanoporeOutputMap;
-
-        //OxfordNanoporeExperiment oxfordNanoporeExperiment = NanoporeParser.parseFileStructure(path);
-        // return oxfordNanoporeExperiment;
+        OxfordNanoporeExperiment nanoporeOutputExperiment = NanoporeParser.parseFileStructure(path);
+        return nanoporeOutputExperiment;
     }
-
-    // TODO: override the shutdown() method if you are implementing a daemon and want to take advantage of a shutdown hook for clean-up tasks
 }

--- a/src/main/java/life/qbic/cli/NanoporeTool.java
+++ b/src/main/java/life/qbic/cli/NanoporeTool.java
@@ -26,12 +26,16 @@ public class NanoporeTool extends QBiCTool<NanoporeCommand> {
     public void execute() {
         // get the parsed command-line arguments
         final NanoporeCommand command = super.getCommand();
-        LOG.debug("Starting Nanopore tool");
-        Map NanoporeOutputMap = runNanoporeParser(command.path);
-        System.out.println(NanoporeOutputMap);
-        LOG.debug("Ending Nanopore tool");
+        LOG.info("Executing NanoporeParser to validate Directory");
+        try {
+            Map NanoporeOutputMap = runNanoporeParser(command.path);
+            LOG.info("Validation process executed successfully");
+        } catch (Exception e) {
+            LOG.error(e.getMessage());
+        }
     }
     //ToDo Switch Map for NanoporeExperiment as soon as it works
+
     private Map runNanoporeParser(Path path) {
 
         Map nanoporeOutputMap = NanoporeParser.parseFileStructure(path);


### PR DESCRIPTION
Works now with the 1.8.0 version of data-model-lib and the 1.4.0 version of core-utils-lib. Changed Code to expect OxfordNanoporeExperiment Object instead of map. 
